### PR TITLE
 x11_in_gtk: add support for min_size and base_size in XSizeHints of …

### DIFF
--- a/src/x11_in_gtk2.c
+++ b/src/x11_in_gtk2.c
@@ -40,6 +40,7 @@ struct _SuilX11Wrapper {
 	bool                        custom_size;
 	int                         req_width;
 	int                         req_height;
+	int                         o;
 };
 
 struct _SuilX11WrapperClass {
@@ -256,8 +257,7 @@ suil_x11_on_size_request(GtkWidget*     widget,
                          GtkRequisition* requisition)
 {
 	SuilX11Wrapper* const self = SUIL_X11_WRAPPER(widget);
-	static int o = 1;
-	if (self->custom_size && o) {
+	if (self->custom_size && self->o) {
 		requisition->width  = self->req_width;
 		requisition->height = self->req_height;
 	} else if (x_window_is_valid(self)) {
@@ -268,7 +268,7 @@ suil_x11_on_size_request(GtkWidget*     widget,
 		XGetWMNormalHints(GDK_WINDOW_XDISPLAY(window),
 			(Window)self->instance->ui_widget,
 			&hints, &supplied);
-		if (o && hints.flags & PBaseSize) {
+		if (self->o && hints.flags & PBaseSize) {
 			requisition->width  = hints.base_width;
 			requisition->height = hints.base_height;
 		} else if (hints.flags & PMinSize) {
@@ -279,7 +279,7 @@ suil_x11_on_size_request(GtkWidget*     widget,
 			requisition->height = self->req_height;
 		}
 	}
-	o ^= 1;
+	self->o ^= 1;
 }
 
 static void
@@ -320,6 +320,7 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->req_width  = 0;
 	self->req_height = 0;
 	self->custom_size = false;
+	self->o           = 1;
 }
 
 static int
@@ -328,9 +329,7 @@ wrapper_resize(LV2UI_Feature_Handle handle, int width, int height)
 	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(handle);
 	wrap->req_width   = width;
 	wrap->req_height  = height;
-	if (width > 0 && height > 0) {
-		wrap->custom_size = true;
-	}
+	wrap->custom_size = width > 0 && height > 0;
 	gtk_widget_queue_resize(GTK_WIDGET(handle));
 	return 0;
 }

--- a/src/x11_in_gtk2.c
+++ b/src/x11_in_gtk2.c
@@ -38,8 +38,6 @@ struct _SuilX11Wrapper {
 	const LV2UI_Idle_Interface* idle_iface;
 	guint                       idle_id;
 	guint                       idle_ms;
-	guint                       min_width;
-	guint                       min_height;
 };
 
 struct _SuilX11WrapperClass {

--- a/src/x11_in_gtk2.c
+++ b/src/x11_in_gtk2.c
@@ -372,9 +372,9 @@ wrapper_wrap(SuilWrapper*  wrapper,
 	                 NULL);
 
 	g_signal_connect(G_OBJECT(wrap),
-					"size-request",
-					G_CALLBACK(suil_x11_on_size_request),
-					NULL);
+	                "size-request",
+	                G_CALLBACK(suil_x11_on_size_request),
+	                NULL);
 
 	g_signal_connect(G_OBJECT(wrap),
 	                 "size-allocate",

--- a/src/x11_in_gtk2.c
+++ b/src/x11_in_gtk2.c
@@ -40,7 +40,7 @@ struct _SuilX11Wrapper {
 	bool                        custom_size;
 	int                         req_width;
 	int                         req_height;
-	int                         o;
+	int                         set_req;
 };
 
 struct _SuilX11WrapperClass {
@@ -257,7 +257,7 @@ suil_x11_on_size_request(GtkWidget*     widget,
                          GtkRequisition* requisition)
 {
 	SuilX11Wrapper* const self = SUIL_X11_WRAPPER(widget);
-	if (self->custom_size && self->o) {
+	if (self->custom_size && self->set_req) {
 		requisition->width  = self->req_width;
 		requisition->height = self->req_height;
 	} else if (x_window_is_valid(self)) {
@@ -268,7 +268,7 @@ suil_x11_on_size_request(GtkWidget*     widget,
 		XGetWMNormalHints(GDK_WINDOW_XDISPLAY(window),
 			(Window)self->instance->ui_widget,
 			&hints, &supplied);
-		if (self->o && hints.flags & PBaseSize) {
+		if (self->set_req && hints.flags & PBaseSize) {
 			requisition->width  = hints.base_width;
 			requisition->height = hints.base_height;
 		} else if (hints.flags & PMinSize) {
@@ -279,7 +279,7 @@ suil_x11_on_size_request(GtkWidget*     widget,
 			requisition->height = self->req_height;
 		}
 	}
-	self->o ^= 1;
+	self->set_req ^= 1;
 }
 
 static void
@@ -320,7 +320,7 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->req_width  = 0;
 	self->req_height = 0;
 	self->custom_size = false;
-	self->o           = 1;
+	self->set_req     = 1;
 }
 
 static int

--- a/src/x11_in_gtk2.c
+++ b/src/x11_in_gtk2.c
@@ -286,7 +286,6 @@ suil_x11_on_size_allocate(GtkWidget*     widget,
 	    && GTK_WIDGET_VISIBLE(widget)) {
 		forward_size_request(self, a);
 	}
-
 }
 
 static void
@@ -298,7 +297,7 @@ suil_x11_on_map_event(GtkWidget*     widget,
 	if ((self->set_custom || self->set_base) && self->set_min) {
 		g_object_set(G_OBJECT(GTK_WIDGET(self)),
 		                      "width-request",self->min_width,
-	                          "height-request",self->min_height,NULL);
+		                      "height-request",self->min_height,NULL);
 	}
 }
 

--- a/src/x11_in_gtk2.c
+++ b/src/x11_in_gtk2.c
@@ -37,7 +37,6 @@ struct _SuilX11Wrapper {
 	const LV2UI_Idle_Interface* idle_iface;
 	guint                       idle_id;
 	guint                       idle_ms;
-	bool                        is_resized;
 	guint                       min_width;
 	guint                       min_height;
 };
@@ -288,17 +287,29 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->instance   = NULL;
 	self->idle_iface = NULL;
 	self->idle_ms    = 1000 / 30;  // 30 Hz default
-	self->is_resized = false;
 	self->min_width  = -1;
 	self->min_height = -1;
+}
+
+static gboolean
+wrapper_set_min_size(void* data)
+{
+	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(data);
+
+	gtk_widget_set_size_request(GTK_WIDGET(wrap), wrap->min_width, wrap->min_height);
+
+	return FALSE;  // One run only
 }
 
 static int
 wrapper_resize(LV2UI_Feature_Handle handle, int width, int height)
 {
 	SuilX11Wrapper* const self = SUIL_X11_WRAPPER(handle);
-	self->is_resized = true;
+
 	gtk_widget_set_size_request(GTK_WIDGET(handle), width, height);
+
+	g_timeout_add(self->idle_ms * 2, wrapper_set_min_size, self);
+
 	return 0;
 }
 
@@ -308,11 +319,6 @@ suil_x11_wrapper_idle(void* data)
 	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(data);
 
 	wrap->idle_iface->idle(wrap->instance->handle);
-
-	if (wrap->is_resized) {
-		gtk_widget_set_size_request(GTK_WIDGET(wrap), wrap->min_width, wrap->min_height);
-		wrap->is_resized = false;
-	}
 
 	return TRUE;  // Continue calling
 }

--- a/src/x11_in_gtk2.c
+++ b/src/x11_in_gtk2.c
@@ -207,6 +207,9 @@ forward_size_request(SuilX11Wrapper* socket,
 			height = MAX(height, hints.min_height);
 			socket->hints.min_width = hints.min_width;
 			socket->hints.min_height = hints.min_height;
+			gtk_widget_set_size_request(GTK_WIDGET(&socket->socket),
+			                            socket->hints.min_width,
+			                            socket->hints.min_height);
 		}
 		if (hints.flags & PAspect) {
 			socket->hints.min_aspect = hints.min_aspect.x/hints.min_aspect.y;
@@ -220,7 +223,6 @@ forward_size_request(SuilX11Wrapper* socket,
 				            GDK_HINT_ASPECT);
 			}
 		}
-
 		// Resize widget window
 		XResizeWindow(GDK_WINDOW_XDISPLAY(window),
 		              (Window)socket->instance->ui_widget,
@@ -298,30 +300,12 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->instance   = NULL;
 	self->idle_iface = NULL;
 	self->idle_ms    = 1000 / 30;  // 30 Hz default
-	self->hints.min_width  = -1;
-	self->hints.min_height = -1;
-}
-
-static gboolean
-wrapper_set_min_size(void* data)
-{
-	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(data);
-
-	gtk_widget_set_size_request(GTK_WIDGET(wrap),
-	                       wrap->hints.min_width,
-	                       wrap->hints.min_height);
-
-	return FALSE;  // One run only
 }
 
 static int
 wrapper_resize(LV2UI_Feature_Handle handle, int width, int height)
 {
-	SuilX11Wrapper* const self = SUIL_X11_WRAPPER(handle);
-
 	gtk_widget_set_size_request(GTK_WIDGET(handle), width, height);
-
-	g_timeout_add(self->idle_ms * 2, wrapper_set_min_size, self);
 
 	return 0;
 }

--- a/src/x11_in_gtk3.c
+++ b/src/x11_in_gtk3.c
@@ -211,6 +211,9 @@ forward_size_request(SuilX11Wrapper* socket,
 			height = MAX(height, hints.min_height);
 			socket->hints.min_width = hints.min_width;
 			socket->hints.min_height = hints.min_height;
+			gtk_widget_set_size_request(GTK_WIDGET(&socket->socket),
+			                            socket->hints.min_width,
+			                            socket->hints.min_height);
 		}
 		if (hints.flags & PAspect) {
 			socket->hints.min_aspect = hints.min_aspect.x/hints.min_aspect.y;
@@ -302,30 +305,12 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->instance   = NULL;
 	self->idle_iface = NULL;
 	self->idle_ms    = 1000 / 30;  // 30 Hz default
-	self->hints.min_width  = -1;
-	self->hints.min_height = -1;
-}
-
-static gboolean
-wrapper_set_min_size(void* data)
-{
-	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(data);
-
-	gtk_widget_set_size_request(GTK_WIDGET(wrap),
-	                       wrap->hints.min_width,
-	                       wrap->hints.min_height);
-
-	return FALSE;  // One run only
 }
 
 static int
 wrapper_resize(LV2UI_Feature_Handle handle, int width, int height)
 {
-	SuilX11Wrapper* const self = SUIL_X11_WRAPPER(handle);
-
 	gtk_widget_set_size_request(GTK_WIDGET(handle), width, height);
-
-	g_timeout_add(self->idle_ms * 2, wrapper_set_min_size, self);
 
 	return 0;
 }

--- a/src/x11_in_gtk3.c
+++ b/src/x11_in_gtk3.c
@@ -40,7 +40,6 @@ struct _SuilX11Wrapper {
 	const LV2UI_Idle_Interface* idle_iface;
 	guint                       idle_id;
 	guint                       idle_ms;
-	bool                        is_resized;
 };
 
 struct _SuilX11WrapperClass {
@@ -303,7 +302,6 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->instance   = NULL;
 	self->idle_iface = NULL;
 	self->idle_ms    = 1000 / 30;  // 30 Hz default
-	self->is_resized = false;
 	self->hints.min_width  = -1;
 	self->hints.min_height = -1;
 }

--- a/src/x11_in_gtk3.c
+++ b/src/x11_in_gtk3.c
@@ -360,6 +360,7 @@ wrapper_resize(LV2UI_Feature_Handle handle, int width, int height)
 	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(handle);
 	wrap->req_width   = width;
 	wrap->req_height  = height;
+	gtk_widget_queue_resize(GTK_WIDGET(handle));
 	return 0;
 }
 

--- a/src/x11_in_gtk3.c
+++ b/src/x11_in_gtk3.c
@@ -39,6 +39,9 @@ struct _SuilX11Wrapper {
 	const LV2UI_Idle_Interface* idle_iface;
 	guint                       idle_id;
 	guint                       idle_ms;
+	bool                        is_resized;
+	guint                       min_width;
+	guint                       min_height;
 };
 
 struct _SuilX11WrapperClass {
@@ -208,6 +211,8 @@ forward_size_request(SuilX11Wrapper* socket,
 		if (hints.flags & PMinSize) {
 			width  = MAX(width, hints.min_width);
 			height = MAX(height, hints.min_height);
+			socket->min_width = hints.min_width;
+			socket->min_height = hints.min_height;
 		}
 
 		// Resize widget window
@@ -287,11 +292,16 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->instance   = NULL;
 	self->idle_iface = NULL;
 	self->idle_ms    = 1000 / 30;  // 30 Hz default
+	self->is_resized = false;
+	self->min_width  = -1;
+	self->min_height = -1;
 }
 
 static int
 wrapper_resize(LV2UI_Feature_Handle handle, int width, int height)
 {
+	SuilX11Wrapper* const self = SUIL_X11_WRAPPER(handle);
+	self->is_resized = true;
 	gtk_widget_set_size_request(GTK_WIDGET(handle), width, height);
 	return 0;
 }
@@ -302,6 +312,11 @@ suil_x11_wrapper_idle(void* data)
 	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(data);
 
 	wrap->idle_iface->idle(wrap->instance->handle);
+
+	if (wrap->is_resized) {
+		gtk_widget_set_size_request(GTK_WIDGET(wrap), wrap->min_width, wrap->min_height);
+		wrap->is_resized = false;
+	}
 
 	return TRUE;  // Continue calling
 }

--- a/src/x11_in_gtk3.c
+++ b/src/x11_in_gtk3.c
@@ -34,12 +34,13 @@ typedef struct _SuilX11WrapperClass SuilX11WrapperClass;
 struct _SuilX11Wrapper {
 	GtkSocket                   socket;
 	GtkPlug*                    plug;
-	GdkGeometry                 hints;
 	SuilWrapper*                wrapper;
 	SuilInstance*               instance;
 	const LV2UI_Idle_Interface* idle_iface;
 	guint                       idle_id;
 	guint                       idle_ms;
+	int                         req_width;
+	int                         req_height;
 };
 
 struct _SuilX11WrapperClass {
@@ -209,23 +210,6 @@ forward_size_request(SuilX11Wrapper* socket,
 		if (hints.flags & PMinSize) {
 			width  = MAX(width, hints.min_width);
 			height = MAX(height, hints.min_height);
-			socket->hints.min_width = hints.min_width;
-			socket->hints.min_height = hints.min_height;
-			gtk_widget_set_size_request(GTK_WIDGET(&socket->socket),
-			                            socket->hints.min_width,
-			                            socket->hints.min_height);
-		}
-		if (hints.flags & PAspect) {
-			socket->hints.min_aspect = hints.min_aspect.x/hints.min_aspect.y;
-			socket->hints.max_aspect = hints.max_aspect.x/hints.max_aspect.y;
-
-			GtkWidget * top = gtk_widget_get_toplevel(GTK_WIDGET(socket->plug));
-			if (gtk_widget_is_toplevel(top)) {
-				gtk_window_set_geometry_hints(GTK_WINDOW(top),
-				            GTK_WIDGET(socket->plug),
-				            &socket->hints,
-				            GDK_HINT_ASPECT);
-			}
 		}
 
 		// Resize widget window
@@ -271,6 +255,65 @@ suil_x11_wrapper_key_event(GtkWidget*   widget,
 }
 
 static void
+suil_x11_wrapper_get_preferred_width (GtkWidget *widget,
+                               gint      *minimal_width,
+                               gint      *natural_width)
+{
+
+	SuilX11Wrapper* const self = SUIL_X11_WRAPPER(widget);
+	if (x_window_is_valid(self)) {
+		GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(self->plug));
+		XSizeHints hints;
+		memset(&hints, 0, sizeof(hints));
+		long supplied;
+		XGetWMNormalHints(GDK_WINDOW_XDISPLAY(window),
+			(Window)self->instance->ui_widget,
+			&hints, &supplied);
+		if (hints.flags & PBaseSize) {
+			(*natural_width)  = hints.base_width;
+		} else {
+			(*natural_width) = self->req_width;
+		}
+		if (hints.flags & PMinSize) {
+			(*minimal_width) = hints.min_width;
+		} else {
+			(*minimal_width) = self->req_width;
+		}
+	} else {
+		(*natural_width) = (*minimal_width) = self->req_width;
+	}
+}
+
+static void
+suil_x11_wrapper_get_preferred_height (GtkWidget *widget,
+                                gint      *minimal_height,
+                                gint      *natural_height)
+{
+	SuilX11Wrapper* const self = SUIL_X11_WRAPPER(widget);
+	if (x_window_is_valid(self)) {
+		GdkWindow* window = gtk_widget_get_window(GTK_WIDGET(self->plug));
+		XSizeHints hints;
+		memset(&hints, 0, sizeof(hints));
+		long supplied;
+		XGetWMNormalHints(GDK_WINDOW_XDISPLAY(window),
+			(Window)self->instance->ui_widget,
+			&hints, &supplied);
+		if (hints.flags & PBaseSize) {
+			(*natural_height)  = hints.base_height;
+		} else {
+			(*natural_height) = self->req_height;
+		}
+		if (hints.flags & PMinSize) {
+			(*minimal_height) = hints.min_height;
+		} else {
+			(*minimal_height) = self->req_height;
+		}
+	} else {
+		(*natural_height) = (*minimal_height) =  self->req_height;
+	}
+}
+
+static void
 suil_x11_on_size_allocate(GtkWidget*     widget,
                           GtkAllocation* a)
 {
@@ -290,11 +333,13 @@ suil_x11_wrapper_class_init(SuilX11WrapperClass* klass)
 	GObjectClass* const   gobject_class = G_OBJECT_CLASS(klass);
 	GtkWidgetClass* const widget_class  = GTK_WIDGET_CLASS(klass);
 
-	gobject_class->finalize         = suil_x11_wrapper_finalize;
-	widget_class->realize           = suil_x11_wrapper_realize;
-	widget_class->show              = suil_x11_wrapper_show;
-	widget_class->key_press_event   = suil_x11_wrapper_key_event;
-	widget_class->key_release_event = suil_x11_wrapper_key_event;
+	gobject_class->finalize            = suil_x11_wrapper_finalize;
+	widget_class->realize              = suil_x11_wrapper_realize;
+	widget_class->show                 = suil_x11_wrapper_show;
+	widget_class->key_press_event      = suil_x11_wrapper_key_event;
+	widget_class->key_release_event    = suil_x11_wrapper_key_event;
+	widget_class->get_preferred_width  = suil_x11_wrapper_get_preferred_width;
+	widget_class->get_preferred_height = suil_x11_wrapper_get_preferred_height;
 }
 
 static void
@@ -305,13 +350,16 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->instance   = NULL;
 	self->idle_iface = NULL;
 	self->idle_ms    = 1000 / 30;  // 30 Hz default
+	self->req_width  = 0;
+	self->req_height = 0;
 }
 
 static int
 wrapper_resize(LV2UI_Feature_Handle handle, int width, int height)
 {
-	gtk_widget_set_size_request(GTK_WIDGET(handle), width, height);
-
+	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(handle);
+	wrap->req_width   = width;
+	wrap->req_height  = height;
 	return 0;
 }
 

--- a/src/x11_in_gtk3.c
+++ b/src/x11_in_gtk3.c
@@ -34,14 +34,13 @@ typedef struct _SuilX11WrapperClass SuilX11WrapperClass;
 struct _SuilX11Wrapper {
 	GtkSocket                   socket;
 	GtkPlug*                    plug;
+	GdkGeometry                 hints;
 	SuilWrapper*                wrapper;
 	SuilInstance*               instance;
 	const LV2UI_Idle_Interface* idle_iface;
 	guint                       idle_id;
 	guint                       idle_ms;
 	bool                        is_resized;
-	guint                       min_width;
-	guint                       min_height;
 };
 
 struct _SuilX11WrapperClass {
@@ -211,8 +210,20 @@ forward_size_request(SuilX11Wrapper* socket,
 		if (hints.flags & PMinSize) {
 			width  = MAX(width, hints.min_width);
 			height = MAX(height, hints.min_height);
-			socket->min_width = hints.min_width;
-			socket->min_height = hints.min_height;
+			socket->hints.min_width = hints.min_width;
+			socket->hints.min_height = hints.min_height;
+		}
+		if (hints.flags & PAspect) {
+			socket->hints.min_aspect = hints.min_aspect.x/hints.min_aspect.y;
+			socket->hints.max_aspect = hints.max_aspect.x/hints.max_aspect.y;
+
+			GtkWidget * top = gtk_widget_get_toplevel(GTK_WIDGET(socket->plug));
+			if (gtk_widget_is_toplevel(top)) {
+				gtk_window_set_geometry_hints(GTK_WINDOW(top),
+				            GTK_WIDGET(socket->plug),
+				            &socket->hints,
+				            GDK_HINT_ASPECT);
+			}
 		}
 
 		// Resize widget window
@@ -293,8 +304,8 @@ suil_x11_wrapper_init(SuilX11Wrapper* self)
 	self->idle_iface = NULL;
 	self->idle_ms    = 1000 / 30;  // 30 Hz default
 	self->is_resized = false;
-	self->min_width  = -1;
-	self->min_height = -1;
+	self->hints.min_width  = -1;
+	self->hints.min_height = -1;
 }
 
 static gboolean
@@ -302,7 +313,9 @@ wrapper_set_min_size(void* data)
 {
 	SuilX11Wrapper* const wrap = SUIL_X11_WRAPPER(data);
 
-	gtk_widget_set_size_request(GTK_WIDGET(wrap), wrap->min_width, wrap->min_height);
+	gtk_widget_set_size_request(GTK_WIDGET(wrap),
+	                       wrap->hints.min_width,
+	                       wrap->hints.min_height);
 
 	return FALSE;  // One run only
 }


### PR DESCRIPTION
…plugin window. Thus allow init a Plugin UI with a default size and shrink it afterwards to the min size.

This is more comparable with the x11_in_qt wrappers. 