### PR TITLE
Let build Qt5 without Cocoa

### DIFF
--- a/wscript
+++ b/wscript
@@ -103,11 +103,11 @@ def configure(conf):
                            uselib_store='QT4',
                            mandatory=False)
 
-        if not conf.options.no_qt5 and not conf.options.no_cocoa:
+        if not conf.options.no_qt5:
             conf.check_pkg('Qt5Widgets >= 5.1.0',
                            uselib_store='QT5',
                            mandatory=False)
-            if conf.check_cxx(header_name = 'QMacCocoaViewContainer',
+            if not conf.options.no_cocoa and conf.check_cxx(header_name = 'QMacCocoaViewContainer',
                               uselib      = 'QT5_COCOA',
                               mandatory   = False):
                 enable_module('SUIL_WITH_COCOA_IN_QT5')


### PR DESCRIPTION
Commit e0678285b5ce373de56f3d2516f03e1187217a17 introduced nococoa flag, but it prevents compilation of Qt5 bindings on some Linux systems.
On some Fedora arches (ARM) QMacCocoaViewContainer is present (I think that is wrong but I can't tell why), so compilation of Qt5 is not possible.
This patch only disables cocoa detection.