### PR TITLE
X11 Drag/Drop Proxy

### DIFF
--- a/src/x11_in_gtk2.c
+++ b/src/x11_in_gtk2.c
@@ -83,7 +83,9 @@ x_window_is_valid(SuilX11Wrapper* socket)
 			return true;
 		}
 	}
-	XFree(children);
+	if (children) {
+		XFree(children);
+	}
 	return false;
 }
 


### PR DESCRIPTION
This adds support for Drag/Drop to reparented X11 windows.

A working example plugin to test/debug X11 events: https://github.com/x42/debug.lv2
See also https://github.com/sadko4u/lsp-plugins/issues/67
